### PR TITLE
Replace UTF character in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 RPIO is an advanced GPIO module for the Raspberry Pi.
 
-* PWM via DMA (up to 1µs resolution)
+* PWM via DMA (up to 1us resolution)
 * GPIO input and output (drop-in replacement for `RPi.GPIO <http://pypi.python.org/pypi/RPi.GPIO>`_)
 * GPIO interrupts (callbacks when events occur on input gpios)
 * TCP socket interrupts (callbacks when tcp socket clients send data)


### PR DESCRIPTION
setup.py failed on my Arch Linux Raspi using Python 3.3 with the following message:

```
[nils@raspi RPIO]$ python setup.py 
Traceback (most recent call last):
  File "setup.py", line 24, in <module>
    long_description=read('README.rst'),
  File "setup.py", line 6, in read
    return open(os.path.join(os.path.dirname(__file__), fname)).read()
  File "/usr/lib/python3.3/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 77: ordinal not in range(128)
```

I could trace the error back to the line

```
* PWM via DMA (up to 1µs resolution)
```

In `README.rst`: The `µ` can't be properly translated to ASCII. This Pull-Request replaces it with a simple `u`.
