### PR TITLE
Mention the Arch Linux PKGBUILD in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ After the installation you can use ``import RPIO`` as well as the command-line t
 
 Debian packages are available at `metachris.github.com/rpio/download <http://metachris.github.com/rpio/download/latest/>`_.
 
+An Arch Linux PKGBUILD is available at `aur.archlinux.org/packages/rpio <https://aur.archlinux.org/packages/rpio/>`_.
+
 
 Examples
 --------


### PR DESCRIPTION
This Pull Request is entirely optional and cosmetic. I made a PKGBUILD for Arch Linux to simplify the installation of RPIO. Using this file, Arch users only need to do

```
wget https://aur.archlinux.org/packages/rp/rpio/PKGBUILD
makepkg -i
```

to install RPIO on their system or 

```
pacman -R rpio
```

to cleanly remove it again.
