### PR TITLE
Corrected a bug in add_channel_pulse which prevented a duty cycle of 100%...

### DIFF
--- a/source/c_pwm/pwm.c
+++ b/source/c_pwm/pwm.c
@@ -458,7 +458,7 @@ add_channel_pulse(int channel, int gpio, int width_start, int width)
     log_debug("add_channel_pulse: channel=%d, gpio=%d, start=%d, width=%d\n", channel, gpio, width_start, width);
     if (!channels[channel].virtbase)
         return fatal("Error: channel %d has not been initialized with 'init_channel(..)'\n", channel);
-    if (width_start + width > channels[channel].width_max || width_start < 0)
+    if (width_start + width > channels[channel].width_max + 1 || width_start < 0)
         return fatal("Error: cannot add pulse to channel %d: width_start+width exceed max_width of %d\n", channel, channels[channel].width_max);
 
     if ((gpio_setup & 1<<gpio) == 0)


### PR DESCRIPTION
...by not allowing setting the very last slot of the subcycle buffer. Check for valid parameter need to be against max_width +1 because max_width is calculated by subtracting 1 and the for-loop runs from 1 to width - 1.
