### PR TITLE
Permit RPIO to control RPi camera LED

### DIFF
--- a/source/c_gpio/py_gpio.c
+++ b/source/c_gpio/py_gpio.c
@@ -59,8 +59,8 @@ static const int (*pin_to_gpio)[27];
 // Board header info is shifted left 8 bits (leaves space for up to 255 channel ids per header)
 #define HEADER_P1 0<<8
 #define HEADER_P5 5<<8
-static const int gpio_to_pin_rev1[32] = {3, 5, -1, -1, 7, -1, -1, 26, 24, 21, 19, 23, -1, -1, 8, 10, -1, 11, 12, -1, -1, 13, 15, 16, 18, 22, -1, -1, -1, -1, -1, -1};
-static const int gpio_to_pin_rev2[32] = {-1, -1, 3, 5, 7, -1, -1, 26, 24, 21, 19, 23, -1, -1, 8, 10, -1, 11, 12, -1, -1, -1, 15, 16, 18, 22, -1, 15, 3 | HEADER_P5, 4 | HEADER_P5, 5 | HEADER_P5, 6 | HEADER_P5};
+static const int gpio_to_pin_rev1[32] = {3, 5, -1, -1, 7, 0, -1, 26, 24, 21, 19, 23, -1, -1, 8, 10, -1, 11, 12, -1, -1, 13, 15, 16, 18, 22, -1, -1, -1, -1, -1, -1};
+static const int gpio_to_pin_rev2[32] = {-1, -1, 3, 5, 7, 0, -1, 26, 24, 21, 19, 23, -1, -1, 8, 10, -1, 11, 12, -1, -1, -1, 15, 16, 18, 22, -1, 15, 3 | HEADER_P5, 4 | HEADER_P5, 5 | HEADER_P5, 6 | HEADER_P5};
 static const int (*gpio_to_pin)[32];
 
 // Flag whether to show warnings


### PR DESCRIPTION
Permit usage of GPIO 5 (in BCM mode) which controls the camera LED for
the RPi's CSI camera module. This patch merely implements compatibility
with the RPi.GPIO package in as much as it permits control of GPIO 5 in
BCM mode (by mapping it to something other than -1) but doesn't
necessarily provide an accurate mapping (if one exists). Hence, the LED
is only controllable from BCM mode, not BOARD mode (this is equivalent
to the RPi.GPIO library).
