### PR TITLE
remove unnecessary clear_channel_gpio in Servo class

### DIFF
--- a/source/RPIO/PWM/__init__.py
+++ b/source/RPIO/PWM/__init__.py
@@ -169,7 +169,6 @@ class Servo:
     """
     _subcycle_time_us = None
     _dma_channel = None
-    _gpios_used = 0  # bitfield to keep track of already added GPIOs
 
     def __init__(self, dma_channel=0, subcycle_time_us=20000, \
             pulse_incr_us=10):
@@ -210,11 +209,6 @@ class Servo:
                         (_subcycle_us, self._subcycle_time_us))
         else:
             init_channel(self._dma_channel, self._subcycle_time_us)
-
-        # If this GPIO is already used, clear it first
-        if self._gpios_used & 1 << gpio:
-            clear_channel_gpio(self._dma_channel, gpio)
-        self._gpios_used |= 1 << gpio
 
         # Add pulse for this GPIO
         add_channel_pulse(self._dma_channel, gpio, 0, \


### PR DESCRIPTION
fixes signal dropout issues that occurred when the pulse width changes
