### PR TITLE
c_gpio: build fix for musl libc

### DIFF
--- a/source/c_gpio/c_gpio.c
+++ b/source/c_gpio/c_gpio.c
@@ -79,7 +79,7 @@ setup(void)
     if ((uint32_t)gpio_mem % PAGE_SIZE)
         gpio_mem += PAGE_SIZE - ((uint32_t)gpio_mem % PAGE_SIZE);
 
-    gpio_map = (uint32_t *)mmap( (caddr_t)gpio_mem, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, mem_fd, GPIO_BASE);
+    gpio_map = (uint32_t *)mmap( (void *)gpio_mem, BLOCK_SIZE, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, mem_fd, GPIO_BASE);
 
     if ((uint32_t)gpio_map < 0)
         return SETUP_MMAP_FAIL;
@@ -163,5 +163,5 @@ void
 cleanup(void)
 {
     // fixme - set all gpios back to input
-    munmap((caddr_t)gpio_map, BLOCK_SIZE);
+    munmap((void *)gpio_map, BLOCK_SIZE);
 }


### PR DESCRIPTION
caddr_t is a legacy BSD type which was rejected by the POSIX standard.
Use void * instead.

This solves a build failure with musl libc.

Fixes #40