### PR TITLE
fix link to kernel.org GPIO docs

### DIFF
--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -83,7 +83,7 @@ Links
 * http://pypi.python.org/pypi/RPIO
 * http://pypi.python.org/pypi/RPi.GPIO
 * http://www.raspberrypi.org/wp-content/uploads/2012/02/BCM2835-ARM-Peripherals.pdf
-* http://www.kernel.org/doc/Documentation/gpio.txt
+* https://www.kernel.org/doc/Documentation/gpio/gpio.txt
 * `semver versioning standard <http://semver.org/>`_
 
 


### PR DESCRIPTION
The link to the kernel.org GPIO Documentation was broken. this fixes it. 