### PR TITLE
Fix 'Page %d not preseent' error. It seems happning with newer OS image.

### DIFF
--- a/source/c_pwm/pwm.c
+++ b/source/c_pwm/pwm.c
@@ -528,7 +528,7 @@ make_pagemap(int channel)
         channels[channel].page_map[i].virtaddr[0] = 0;
         if (read(fd, &pfn, sizeof(pfn)) != sizeof(pfn))
             return fatal("rpio-pwm: Failed to read %s: %m\n", pagemap_fn);
-        if (((pfn >> 55) & 0x1bf) != 0x10c)
+        if (((pfn >> 55) & 0x181) != 0x100)
             return fatal("rpio-pwm: Page %d not present (pfn 0x%016llx)\n", i, pfn);
         channels[channel].page_map[i].physaddr = (uint32_t)pfn << PAGE_SHIFT | 0x40000000;
     }


### PR DESCRIPTION
ocumentation/vm/pagemap.txt
Accouding to kernel document, Bits57-60 must be zero in current kernel.
So Mask those bits.
It works fine with Raspberry Pi zero with Linux raspberrypi 4.4.11+ kernel.
