### PR TITLE
Python 3.4 TCP Client Keys

### DIFF
--- a/source/RPIO/_RPIO.py
+++ b/source/RPIO/_RPIO.py
@@ -350,7 +350,7 @@ class Interruptor:
         """
         Closes all TCP connections and then the socket servers
         """
-        for fileno in self._tcp_client_sockets.keys():
+        for fileno in list(self._tcp_client_sockets.keys()):
             self.close_tcp_client(fileno)
         for fileno, items in self._tcp_server_sockets.items():
             socket, cb = items


### PR DESCRIPTION
Hi there,
When you run `RPIO.cleanup_tcpsockets()` on a RPi Model B+ running Python 3.4 then you get an error message about your dictionary changing sizes during iterations (see error message below). I think the issue was because keys() now returns an iterable instead of a list in Python 3, so I just wrapped list around it to get a static list that wouldn't change size. I tested it and it doesn't interfere with the DMA PWM stuff at least, and I don't get thrown the error anymore. This would decrease performance only a tiny bit anyways as a type safety issue.

Best,
Jeff

`Traceback (most recent call last):
  File "rpi_client.py", line 66, in <module>
    RPIO.wait_for_interrupts()
    content.strip())
  File "rpi_client.py", line 24, in tcp_callback
    RPIO.cleanup()
  File "/usr/local/lib/python3.4/dist-packages/RPIO-2.0.0_beta1-py3.4-linux-armv6l.egg/RPIO/__init__.py", line 281, in cleanup
    cleanup_interrupts()
  File "/usr/local/lib/python3.4/dist-packages/RPIO-2.0.0_beta1-py3.4-linux-armv6l.egg/RPIO/__init__.py", line 271, in cleanup_interrupts
    _rpio.cleanup_interrupts()
  File "/usr/local/lib/python3.4/dist-packages/RPIO-2.0.0_beta1-py3.4-linux-armv6l.egg/RPIO/_RPIO.py", line 368, in cleanup_interrupts
    self.cleanup_tcpsockets()
  File "/usr/local/lib/python3.4/dist-packages/RPIO-2.0.0_beta1-py3.4-linux-armv6l.egg/RPIO/_RPIO.py", line 353, in cleanup_tcpsockets
    for fileno in self._tcp_client_sockets.keys():
RuntimeError: dictionary changed size during iteration`